### PR TITLE
FHIR R4 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ tmp/
 .idea/**/tasks.xml
 .idea/dictionaries
 
+.editorconfig
+
 # Target objects
 target/
 

--- a/src/main/java/edu/phema/elm_to_omop/translate/CorelatedCriteriaTranslator.java
+++ b/src/main/java/edu/phema/elm_to_omop/translate/CorelatedCriteriaTranslator.java
@@ -77,6 +77,8 @@ public class CorelatedCriteriaTranslator {
             return generateCorelatedCriteriaForExpression(((Exists) expression).getOperand(), context);
         } else if (expression instanceof Query) {
             return generateCorelatedCriteriaForQuery((Query) expression, context);
+        } else if (expression instanceof Not) {
+            return ComparisonExpressionTranslator.generateCorelatedCriteriaForExclusion(expression, context);
         } else if (ComparisonExpressionTranslator.isNumericComparison(expression)) {
             return ComparisonExpressionTranslator.generateCorelatedCriteriaForComparison(expression, context);
         } else {

--- a/src/main/java/edu/phema/elm_to_omop/translate/PhemaElmToOmopTranslator.java
+++ b/src/main/java/edu/phema/elm_to_omop/translate/PhemaElmToOmopTranslator.java
@@ -82,8 +82,7 @@ public class PhemaElmToOmopTranslator {
 
     public static boolean isBooleanExpression(Expression expression) {
         return (expression instanceof Or) ||
-            (expression instanceof And) ||
-            (expression instanceof Not);
+            (expression instanceof And);
     }
 
     /**

--- a/src/main/java/edu/phema/elm_to_omop/translate/criteria/comparison/ComparisonExpressionTranslator.java
+++ b/src/main/java/edu/phema/elm_to_omop/translate/criteria/comparison/ComparisonExpressionTranslator.java
@@ -74,6 +74,31 @@ public class ComparisonExpressionTranslator {
     }
 
     /**
+     * Create CorelatedCriteria for an exclusion (specifically a Not expression)
+     * @param expression The Not expression
+     * @param context The translator context
+     * @return A CorelatedCriteria entry for this expression
+     * @throws Exception
+     */
+    public static CorelatedCriteria generateCorelatedCriteriaForExclusion(Expression expression, PhemaElmToOmopTranslatorContext context) throws Exception {
+        if (!(expression instanceof Not)) {
+            throw new PhemaTranslationException(String.format("Unsupported exclusion operation: s", expression.getClass().getSimpleName()));
+        }
+
+        // In Atlas, "exclusion" is an assertion that the count of a concept is exactly 0
+        Occurrence occurrence = CirceUtil.defaultOccurrence();
+        occurrence.count = 0;
+        occurrence.type = Occurrence.EXACTLY;
+
+        CorelatedCriteria corelatedCriteria = CorelatedCriteriaTranslator.generateCorelatedCriteriaForExpression(
+            ((UnaryExpression)expression).getOperand(), context);
+
+        corelatedCriteria.occurrence = occurrence;
+
+        return corelatedCriteria;
+    }
+
+    /**
      * Right now we only support the simple comparison of the form Count(X) > y, where X is a Retrieve or Query
      * expression and y is a number.
      *

--- a/src/main/java/edu/phema/elm_to_omop/translate/util/map/FhirResourceCirceCriteriaMap.java
+++ b/src/main/java/edu/phema/elm_to_omop/translate/util/map/FhirResourceCirceCriteriaMap.java
@@ -18,13 +18,16 @@ public class FhirResourceCirceCriteriaMap {
 
     static {
         resourceCriteriaMap.put("Encounter", VisitOccurrence.class);
-
         resourceCriteriaMap.put("Procedure", ProcedureOccurrence.class);
+        // TODO we need to disambiguate mappings for Procedure
+        // resourceCriteriaMap.put("Procedure", DeviceExposure.class);
         resourceCriteriaMap.put("Observation", Measurement.class);
+        // TODO we need to disambiguate mappings for Observation
+        // resourceCriteriaMap.put("Observation", Observation.class);
         resourceCriteriaMap.put("MedicationRequest", DrugExposure.class);
         resourceCriteriaMap.put("Condition", ConditionOccurrence.class);
-
-        // resourceCriteriaMap.put("AdverseEvent", Death.class);
+        resourceCriteriaMap.put("AdverseEvent", Death.class);
+        resourceCriteriaMap.put("Specimen", Specimen.class);
     }
 }
 

--- a/src/main/java/edu/phema/elm_to_omop/translate/util/map/FhirResourceCirceCriteriaMap.java
+++ b/src/main/java/edu/phema/elm_to_omop/translate/util/map/FhirResourceCirceCriteriaMap.java
@@ -1,0 +1,30 @@
+package edu.phema.elm_to_omop.translate.util.map;
+
+import org.ohdsi.circe.cohortdefinition.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mappings are from the Common Data Model Harmonization project, and can be found at
+ * http://build.fhir.org/ig/HL7/cdmh/profiles.html#omop-to-fhir-mappings
+ */
+public class FhirResourceCirceCriteriaMap {
+    private FhirResourceCirceCriteriaMap()  {
+        super();
+    }
+
+    public static final Map<String, Class<? extends Criteria>> resourceCriteriaMap = new HashMap<>();
+
+    static {
+        resourceCriteriaMap.put("Encounter", VisitOccurrence.class);
+
+        resourceCriteriaMap.put("Procedure", ProcedureOccurrence.class);
+        resourceCriteriaMap.put("Observation", Measurement.class);
+        resourceCriteriaMap.put("MedicationRequest", DrugExposure.class);
+        resourceCriteriaMap.put("Condition", ConditionOccurrence.class);
+
+        // resourceCriteriaMap.put("AdverseEvent", Death.class);
+    }
+}
+


### PR DESCRIPTION
Explicit support for FHIR R4 per #36.  We retain what QUICK support was already there for backward compatibility, but no expectation we're going to extend it going forward (unless we identify a need to).